### PR TITLE
Fix compatibility with home-manager

### DIFF
--- a/common.nix
+++ b/common.nix
@@ -85,7 +85,7 @@ in
     };
 
     # Load the environment populated from `sommelier`, e.g. `DISPLAY`.
-    shellInit = builtins.readFile "${cros-container-guest-tools-src}/cros-sommelier/sommelier.sh";
+    shellInit = builtins.readFile ./sommelier.sh;
   };
 
   system.activationScripts = {

--- a/sommelier.sh
+++ b/sommelier.sh
@@ -1,0 +1,31 @@
+# Derived from sommelier.sh from https://chromium.googlesource.com/chromiumos/containers/cros-container-guest-tools
+# Original source: Copyright 2019 The ChromiumOS Authors
+
+# Not running under sommelier?
+if ! systemctl --user show-environment | grep -q '^SOMMELIER_VERSION='; then
+  return 0
+fi
+
+# Helper function to export a variable if it isn't already set
+__sommelier_export() {
+  local var="$1"
+  # We have to resort to eval as POSIX doesn't support ${!var} indirection.
+  if [ -n "$(eval \"[ -z \"\${${var}}\" ] || echo unset\")" ]; then
+    local setting
+    # Only export the var if it's been defined.  This might be an account that
+    # the user has setup or modified.  No point in spewing errors.
+    if setting="$(systemctl --user show-environment | grep "^${var}=")"; then
+      export "${setting}"
+    fi
+  fi
+}
+
+__sommelier_export DISPLAY
+__sommelier_export DISPLAY_LOW_DENSITY
+__sommelier_export XCURSOR_SIZE
+__sommelier_export XCURSOR_SIZE_LOW_DENSITY
+__sommelier_export WAYLAND_DISPLAY
+__sommelier_export WAYLAND_DISPLAY_LOW_DENSITY
+
+# No need to export this to the shell env.
+unset -f __sommelier_export

--- a/sommelier.sh
+++ b/sommelier.sh
@@ -10,7 +10,7 @@ fi
 __sommelier_export() {
   local var="$1"
   # We have to resort to eval as POSIX doesn't support ${!var} indirection.
-  if [ -n "$(eval \"[ -z \"\${${var}}\" ] || echo unset\")" ]; then
+  if [ -n "$(eval "[ -z \"\${$var}\" ] || echo unset")" ]; then
     local setting
     # Only export the var if it's been defined.  This might be an account that
     # the user has setup or modified.  No point in spewing errors.


### PR DESCRIPTION
Home-manager's `hm-setup-env` scripts get invoked with `set -el`, resulting in /etc/profile being sourced, but terminating on errors.

The implementation of `__sommelier_export` from upstream  `sommelier.sh` uses an eval which seems to trip the `-e` flag, making home-manager's user service fail to run. 

This fixes that, in a way that should also maintain posix compatibility