### PR TITLE
Set hostname as a default

### DIFF
--- a/baguette.nix
+++ b/baguette.nix
@@ -80,7 +80,7 @@
       };
 
       networking = {
-        hostName = "baguette-nixos";
+        hostName = lib.mkDefault "baguette-nixos";
         useHostResolvConf = true;
         resolvconf.enable = false;
         dhcpcd.enable = false;


### PR DESCRIPTION
Allow for users to set hostname on baguette, without requiring them to use mkForce