### PR TITLE
Add determinate systems flake updater action

### DIFF
--- a/.github/workflows/nix-flake-update-pr.yml
+++ b/.github/workflows/nix-flake-update-pr.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
       - name: setup nix
-        uses: cachix/install-nix-action@4e002c8ec80594ecd40e759629461e26c8abed15 #v24
+        uses: cachix/install-nix-action@4e002c8ec80594ecd40e759629461e26c8abed15 #v31
         with:
           nix_path: nixpkgs=channel:nixos-unstable
 


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automate updating Nix dependencies. The workflow is scheduled to run weekly and can also be triggered manually.

**Automation and CI enhancements:**

* Introduced a `.github/workflows/update-flakes.yml` workflow that automatically updates Nix flake inputs, creates a pull request with the changes, and applies relevant labels. The workflow runs weekly and supports manual triggering.