### PR TITLE
Migrate to services.journald.settings

### DIFF
--- a/baguette.nix
+++ b/baguette.nix
@@ -107,9 +107,7 @@
         '';
 
         # https://chromium.googlesource.com/chromiumos/platform2/+/HEAD/vm_tools/baguette_image/src/data/usr/local/lib/systemd/journald.conf.d/50-console.conf?autodive=0%2F%2F%2F
-        journald.extraConfig = ''
-          ForwardToConsole=yes
-        '';
+        journald.settings.Journal.ForwardToConsole = true;
 
         # D-Bus service for cros-notificationd activation
         # https://chromium.googlesource.com/chromiumos/containers/cros-container-guest-tools/+/refs/heads/main/cros-notificationd/org.freedesktop.Notifications.service


### PR DESCRIPTION
`services.journald.extraConfig` was removed in recent nixpkgs; any definition of it now fails evaluation with:

```
The option definition `services.journald.extraConfig' in `…/baguette.nix' no longer has any effect; please remove it.
Use services.journald.settings.Journal instead.
```

This expresses `ForwardToConsole=yes` through the structured `services.journald.settings` option instead, which renders the same journald.conf drop-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NeD2R83ZFEe2G68D7Ybymg