### PR TITLE
Allow adding `crostini.enable` to users

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
       - uses: DeterminateSystems/flake-checker-action@3164002371bc90729c68af0e24d5aacf20d7c9f6  # v12
 
       - run: nix flake check --no-build
+      - name: Check the guest session contract and boot log verifier
+        run: nix build --no-link .#checks.${{ matrix.system }}.guest-session .#checks.${{ matrix.system }}.boot-verifier
       - run: nix build --no-link .#baguette-tarball .#lxc-image-and-metadata .#termina-kernel
       # The quick start of the README, as written: every `quick-start`
       # block, in order, with this checkout in place of the repository on

--- a/README.md
+++ b/README.md
@@ -78,6 +78,14 @@ To add `baguette` support to your NixOS existing configuration:
 
 1. Add this flake as an input.
 1. Add `inputs.nixos-crostini.nixosModules.baguette` to your modules.
+1. Enable `crostini.enable` for your user:
+
+```nix
+users.users.aldur = {
+  isNormalUser = true;
+  crostini.enable = true;
+};
+```
 
 Here is a _very minimal_ example:
 

--- a/baguette.nix
+++ b/baguette.nix
@@ -291,9 +291,6 @@
         tss = { };
       };
 
-      # NOTE: There's no need to manually create a user here,
-      # since it will be created by `vmc start ...` or equivalent.
-
       systemd = {
         # ChromeOS VM integration services
         mounts = [
@@ -317,47 +314,59 @@
           }
         ];
 
-        services = {
-          vshd = {
-            description = "vshd";
-            after = [ "opt-google-cros\\x2dcontainers.mount" ];
-            requires = [ "opt-google-cros\\x2dcontainers.mount" ];
-            wantedBy = [ "basic.target" ];
+        # Only an explicitly selected account gets the boot-session dependency.
+        services =
+          lib.listToAttrs (
+            map (
+              user:
+              lib.nameValuePair "user@${toString user.uid}" {
+                overrideStrategy = "asDropin";
+                enableDefaultPath = false;
+                requires = [ "opt-google-cros\\x2dcontainers.mount" ];
+                after = [ "opt-google-cros\\x2dcontainers.mount" ];
+              }
+            ) (lib.filter (user: user.crostini.enable) (lib.attrValues config.users.users))
+          )
+          // {
+            vshd = {
+              description = "vshd";
+              after = [ "opt-google-cros\\x2dcontainers.mount" ];
+              requires = [ "opt-google-cros\\x2dcontainers.mount" ];
+              wantedBy = [ "basic.target" ];
 
-            serviceConfig = {
-              ExecStart = "/opt/google/cros-containers/bin/vshd";
+              serviceConfig = {
+                ExecStart = "/opt/google/cros-containers/bin/vshd";
+              };
+            };
+
+            maitred = {
+              description = "maitred";
+              after = [ "opt-google-cros\\x2dcontainers.mount" ];
+              requires = [ "opt-google-cros\\x2dcontainers.mount" ];
+              wantedBy = [ "basic.target" ];
+
+              serviceConfig = {
+                ExecStart = "/opt/google/cros-containers/bin/maitred";
+                Environment = "PATH=/opt/google/cros-containers/bin:/usr/sbin:/usr/bin:/sbin:/bin:/run/current-system/sw/bin";
+              };
+            };
+
+            cros-port-listener = {
+              description = "Chromium OS port listener service";
+              after = [ "opt-google-cros\\x2dcontainers.mount" ];
+              requires = [ "opt-google-cros\\x2dcontainers.mount" ];
+              wantedBy = [ "basic.target" ];
+
+              serviceConfig = {
+                Type = "simple";
+                ExecStart = "/opt/google/cros-containers/bin/port_listener";
+                Restart = "always";
+                # Without a delay, a missing binary restarts in a tight loop
+                # and floods the console until the start limit.
+                RestartSec = 1;
+              };
             };
           };
-
-          maitred = {
-            description = "maitred";
-            after = [ "opt-google-cros\\x2dcontainers.mount" ];
-            requires = [ "opt-google-cros\\x2dcontainers.mount" ];
-            wantedBy = [ "basic.target" ];
-
-            serviceConfig = {
-              ExecStart = "/opt/google/cros-containers/bin/maitred";
-              Environment = "PATH=/opt/google/cros-containers/bin:/usr/sbin:/usr/bin:/sbin:/bin:/run/current-system/sw/bin";
-            };
-          };
-
-          cros-port-listener = {
-            description = "Chromium OS port listener service";
-            after = [ "opt-google-cros\\x2dcontainers.mount" ];
-            requires = [ "opt-google-cros\\x2dcontainers.mount" ];
-            wantedBy = [ "basic.target" ];
-
-            serviceConfig = {
-              Type = "simple";
-              ExecStart = "/opt/google/cros-containers/bin/port_listener";
-              Restart = "always";
-              # Without a delay, a missing binary restarts in a tight loop
-              # and floods the console until the start limit.
-              RestartSec = 1;
-            };
-          };
-
-        };
 
         user.services.cros-notificationd = {
           description = "Chromium OS Notification Server";

--- a/common.nix
+++ b/common.nix
@@ -6,6 +6,10 @@
 }:
 
 let
+  selectedUsers = lib.filterAttrs (_: user: user.crostini.enable) config.users.users;
+  users = lib.attrValues selectedUsers;
+  user = if lib.length users == 1 then lib.head users else null;
+
   cros-container-guest-tools-src-version = "4ef17fb17e0617dff3f6e713c79ce89fee4e60f7";
 
   cros-container-guest-tools-src = pkgs.fetchgit {
@@ -53,6 +57,24 @@ let
 in
 {
   options = {
+    users.users = lib.mkOption {
+      type = lib.types.attrsOf (
+        lib.types.submodule (
+          { config, ... }: {
+            options.crostini.enable = lib.mkEnableOption "register this user with ChromeOS";
+            config = lib.mkIf config.crostini.enable {
+              uid = lib.mkDefault 1000;
+              linger = lib.mkDefault true;
+              extraGroups = [
+                "video"
+                "render"
+              ];
+            };
+          }
+        )
+      );
+    };
+
     crostini = {
       sommelier.stableScaling = lib.mkEnableOption "`--stable-scaling` for the X11 sommelier" // {
         description = ''
@@ -85,6 +107,30 @@ in
   };
 
   config = {
+    warnings = lib.optional (users == [ ]) ''
+      No user has crostini.enable set. Set `users.users.<name>.crostini.enable
+      = true` to start that user's session at boot. 
+    '';
+
+    assertions = [
+      {
+        assertion = lib.length users <= 1;
+        message = "Crostini: only one user may enable crostini.enable; enabled for: ${
+          lib.concatMapStringsSep ", " (name: "users.users.${name}") (lib.attrNames selectedUsers)
+        }.";
+      }
+    ]
+    ++ lib.concatMap (account: [
+      {
+        assertion = account.enable && account.isNormalUser && !account.isSystemUser && account.uid != 0;
+        message = "Crostini: ${account.name} must be an enabled normal user, not root or a system account.";
+      }
+      {
+        assertion = account.linger == true;
+        message = "Crostini: ${account.name} requires `linger = true` for registration before login.";
+      }
+    ]) users;
+
     networking = {
       # The eth0 interface in this container/VM can only be accessed from the host.
       firewall.enable = false;
@@ -176,33 +222,47 @@ in
       '';
     };
 
-    # The LXC module of nixpkgs imports the minimal profile, which turns
-    # off the MIME defaults and the icon directories of the system path.
-    # garcon needs the first, the UI integration the second.
-    xdg.mime.enable = true;
-    xdg.icons.enable = true;
+    xdg = {
+      # The LXC module of nixpkgs imports the minimal profile, which turns
+      # off the MIME defaults and the icon directories of the system path.
+      # garcon needs the first, the UI integration the second.
+      mime.enable = true;
+      icons.enable = true;
 
-    # Taken from https://aur.archlinux.org/packages/cros-container-guest-tools-git
-    xdg.mime.defaultApplications = {
-      "text/html" = "garcon_host_browser.desktop";
-      "x-scheme-handler/http" = "garcon_host_browser.desktop";
-      "x-scheme-handler/https" = "garcon_host_browser.desktop";
-      "x-scheme-handler/about" = "garcon_host_browser.desktop";
-      "x-scheme-handler/unknown" = "garcon_host_browser.desktop";
+      # Taken from https://aur.archlinux.org/packages/cros-container-guest-tools-git
+      mime.defaultApplications = {
+        "text/html" = "garcon_host_browser.desktop";
+        "x-scheme-handler/http" = "garcon_host_browser.desktop";
+        "x-scheme-handler/https" = "garcon_host_browser.desktop";
+        "x-scheme-handler/about" = "garcon_host_browser.desktop";
+        "x-scheme-handler/unknown" = "garcon_host_browser.desktop";
+      };
     };
 
     systemd = {
       user = {
         services = {
           garcon = {
-            # TODO: In the original service definition this only starts _after_ sommelier.
             description = "Chromium OS Garcon Bridge";
+            # Other accounts can use the displays without registering a
+            # second garcon session when a diagnostic login is opened.
+            unitConfig.ConditionUser = lib.mkIf (user != null) user.name;
             wantedBy = [ "default.target" ];
+            # The notify services publish the displays before garcon can
+            # launch applications on behalf of the host.
+            requires = [
+              "sommelier@0.service"
+              "sommelier@1.service"
+              "sommelier-x@0.service"
+              "sommelier-x@1.service"
+            ];
+            after = config.systemd.user.services.garcon.requires;
             serviceConfig = {
               ExecStart = "/opt/google/cros-containers/bin/garcon --server";
               Type = "simple";
               ExecStopPost = "/opt/google/cros-containers/bin/guest_service_failure_notifier cros-garcon";
               Restart = "always";
+              RestartSec = 1;
             };
             environment = {
               BROWSER = lib.getExe' cros-container-guest-tools "garcon-url-handler";

--- a/configuration.nix
+++ b/configuration.nix
@@ -5,10 +5,13 @@
 {
   # inputs,
   # lib,
-  # config,
   pkgs,
   ...
 }:
+let
+  # TODO: Replace `aldur` with the username you picked when configuring Linux in ChromeOS.
+  user = "aldur";
+in
 {
   imports = [
     # You can import other NixOS modules here.
@@ -30,12 +33,9 @@
 
   # Configure your system-wide user settings (groups, etc), add more users as needed.
   users.users = {
-    # TODO: Replace `aldur` with the username you picked when configuring Linux
-    # in ChromeOS.
-    aldur = {
+    ${user} = {
       isNormalUser = true;
-
-      linger = true;
+      crostini.enable = true;
       extraGroups = [ "wheel" ];
     };
   };

--- a/flake.nix
+++ b/flake.nix
@@ -107,30 +107,24 @@
         baguette-boot = self.lib.mkBaguetteTest {
           configuration = baguetteNixosFor system;
         };
-        baguette-boot-termina =
-          let
-            kernel = self.packages.${system}.termina-kernel;
-          in
-          self.lib.mkBaguetteSmokeTest {
-            configuration = baguetteNixosFor system;
-            name = "baguette-boot-termina";
-            kernel = "${kernel}/kernel";
-            kernelRelease = "${kernel}/release";
-            extraProbe = ''
-              echo "PROBE kernel-modules $(test -e /proc/modules && echo present || echo absent)"
-            '';
-            extraChecks = [
-              "kernel-modules absent$"
-            ];
-          };
+        baguette-boot-termina = self.lib.mkBaguetteSmokeTest {
+          configuration = baguetteNixosFor system;
+          name = "baguette-boot-termina";
+        };
+        guest-session = import ./tests/guest-session.nix { inherit nixpkgs system; };
+        boot-verifier = import ./tests/verify-boot.nix {
+          pkgs = nixpkgs.legacyPackages.${system};
+        };
         lxc-boot = self.lib.mkLxcTest {
           configuration = lxcNixosFor system;
         };
       });
 
-      lib.mkBaguetteTest = import ./tests/baguette-boot.nix { inherit (nixpkgs) lib; };
-      lib.mkBaguetteSmokeTest = import ./tests/baguette-smoke.nix { inherit (nixpkgs) lib; };
-      lib.mkLxcTest = import ./tests/lxc-boot.nix { inherit (nixpkgs) lib; };
+      lib = {
+        mkBaguetteTest = import ./tests/baguette-boot.nix { inherit (nixpkgs) lib; };
+        mkBaguetteSmokeTest = import ./tests/baguette-smoke.nix { inherit (nixpkgs) lib; };
+        mkLxcTest = import ./tests/lxc-boot.nix { inherit (nixpkgs) lib; };
+      };
 
       nixosConfigurations = {
         # This allows you to re-build the image from inside the container/VM.

--- a/tests/baguette-boot.nix
+++ b/tests/baguette-boot.nix
@@ -1,5 +1,6 @@
 # Adapted from aldur/dotfiles (utils/baguette-test.nix, commit 4f804055).
-# Boots the shipped Baguette image in crosvm and runs a probe inside it.
+# An instrumented GUI/rebuild scenario, not the ChromeOS boot contract.
+# The separate baguette-smoke.nix checks unassisted no-initrd startup.
 # flake.nix exports this function as `lib.mkBaguetteTest`.
 #
 # The image has no kernel: Baguette boots the ChromeOS kernel. The test
@@ -33,7 +34,7 @@ in
   # Attribute name of the derivation.
   name ? "baguette-boot",
   # The interactive user of the guest.
-  user ? shared.defaultUser "mkBaguetteTest" configuration,
+  user ? shared.defaultUser "baguette-boot" configuration,
   # Files for `/opt/google/cros-containers/probe`, as name-to-path pairs.
   # The probe reads them from `$probe`.
   probeFiles ? { },
@@ -227,7 +228,8 @@ let
         run_as() {
           local name=$1 uid=$2
           shift 2
-          runuser -u $name -- env HOME=/home/$name XDG_RUNTIME_DIR=/run/user/$uid "$@"
+          setpriv --reuid "$uid" --regid "$(id -gn "$name")" --init-groups \
+            env HOME=/home/$name XDG_RUNTIME_DIR=/run/user/$uid "$@"
         }
         as_user() {
           run_as $user 1000 ${
@@ -271,6 +273,22 @@ let
     echo "PROBE journald $(grep '^ForwardToConsole=' /etc/systemd/journald.conf)"
     ${shared.commonModuleProbe}
 
+    # Assert the boot contract before a login, user provisioning or any
+    # explicit service start. Recheck on the second boot as well.
+    for _ in $(seq 60); do
+      systemctl is-active --quiet user@1000.service && break
+      sleep 1
+    done
+    systemctl is-active --quiet user@1000.service || exit 1
+    for unit in garcon.service sommelier@0.service sommelier@1.service sommelier-x@0.service sommelier-x@1.service; do
+      for _ in $(seq 60); do
+        as_user systemctl --user is-active --quiet "$unit" && break
+        sleep 1
+      done
+      as_user systemctl --user is-active --quiet "$unit" || exit 1
+    done
+    echo "PROBE unassisted-session active"
+
     # `vmc start` asks maitred to set up the user: `useradd` for a new
     # name, with the shell /bin/bash, or `usermod` for a known one, both
     # with the groups vmc passes by default, then linger through logind.
@@ -284,7 +302,14 @@ let
         /usr/sbin/useradd --uid $uid --create-home --shell /bin/bash --groups $vmc_groups $name \
           && result=useradd || result=useradd-failed
       fi
-      loginctl enable-linger $name
+      # Only the synthetic secondary user needs host provisioning here.
+      # Never repair the selected account, even in this instrumented test.
+      if [ "$name" != "$user" ]; then
+        # This secondary-account GUI fixture needs render access too.
+        # It is not evidence for ChromeOS host provisioning behavior.
+        /usr/sbin/usermod --append --groups render "$name"
+        loginctl enable-linger "$name"
+      fi
       echo "PROBE vmc-user $name $result" \
         "groups=$(id -Gn $name | tr ' ' '\n' | grep -c -x -F -f <(echo $vmc_groups | tr , '\n'))/11" \
         "shell=$(getent passwd $name | cut -d : -f 7)"
@@ -292,9 +317,7 @@ let
 
     # The windows of the guest go through sommelier. Its units come from
     # the image; the binary and its GBM backend come from the tools disk.
-    # On ChromeOS, maitred opens the user session and grants the render
-    # node.
-    chmod 0666 /dev/dri/renderD128 2>/dev/null
+    # Device access must come from the selected account's declared groups.
     vmc_user $user 1000
     for _ in $(seq 30); do
       as_user systemctl --user is-active --quiet sommelier@0.service 2>/dev/null && break
@@ -566,6 +589,7 @@ let
     shared.commonChecks user
     ++ shared.commonModuleChecks configuration
     ++ [
+      "unassisted-session active$"
       "system ${booted}$"
       "profile ${booted}$"
       "nix-db valid registration-consumed$"
@@ -573,7 +597,7 @@ let
       # or `prepare-root` with the systemd initrd.
       "init ${booted}/${initScript}$"
       "resolv /run/resolv.conf$"
-      "home ${user} ${configuration.config.users.users.${user}.homeMode}$"
+      "home ${user} ${(shared.userAccount configuration user).homeMode}$"
       "boot-dir present$"
       "usermod /nix/store/.*/usermod"
       "zoneinfo /etc/zoneinfo$"
@@ -667,6 +691,7 @@ pkgs.runCommand name
       pkgs.weston
     ];
     requiredSystemFeatures = [ "kvm" ];
+    passthru = { inherit probe; };
   }
   ''
     # A disk 2 GiB larger than the image, to also cover the resize at boot.

--- a/tests/baguette-smoke.nix
+++ b/tests/baguette-smoke.nix
@@ -1,228 +1,222 @@
-# A boot smoke test for a ChromeOS Baguette image. It boots the image in
-# crosvm and runs a probe inside it. flake.nix exports this function as
-# `lib.mkBaguetteSmokeTest`. The full GUI/reboot test is baguette-boot.nix.
-#
-# The image has no kernel: Baguette boots the ChromeOS kernel. By default
-# the test boots the image with the kernel and the initrd of the same
-# configuration, with `boot.kernel` and `boot.initrd` turned back on. With
-# `kernel`, it boots that image instead, with no initrd and the root on the
-# command line, as ChromeOS does. The disk is the image CI ships, unchanged.
-#
-# ChromeOS mounts a `cros-vm-tools` disk with maitred, vshd, garcon, and
-# sommelier. Those binaries are not public. The test mounts a disk with that
-# label that carries sommelier from nixpkgs, stand-ins for the daemons, the
-# probe, and the files the caller passes. So the test covers the guest side
-# of the ChromeOS integration, not the host side: the ChromeOS daemons that
-# talk to maitred and garcon have no counterpart here.
+# A guest smoke test, not a ChromeOS host integration test. Keep boot and
+# session startup unassisted; only the tools disk and compositor are fixtures.
+# Uses the distributed root image and a representative Termina kernel,
+# without an initrd. Exact host registration still requires ChromeOS.
 { lib }:
 let
   shared = import ./lib.nix { inherit lib; };
 in
 {
-  # The `nixosSystem` that builds the image. It must import
-  # `nixos-crostini.nixosModules.baguette`.
   configuration,
-  # Attribute name of the derivation.
-  name ? "baguette-boot",
-  # The interactive user of the guest.
-  user ? shared.defaultUser "mkBaguetteSmokeTest" configuration,
-  # Files for `/opt/google/cros-containers/probe`, as name-to-path pairs.
-  # The probe reads them from `$probe`.
+  name ? "baguette-smoke",
+  user ? shared.defaultUser "baguette-smoke" configuration,
   probeFiles ? { },
-  # Environment for `as_user`. The probe runs from a unit, not a login
-  # session, so it does not have `environment.sessionVariables`.
-  userEnv ? { },
-  # Shell lines for the probe. Each `PROBE <text>` line they print reaches
-  # the checks below. They run as root, with the tools of the image only.
-  # `as_user CMD` runs a command as the interactive user.
   extraProbe ? "",
-  # Extended regular expressions, each matched against one `PROBE` line.
   extraChecks ? [ ],
-  # A kernel image to boot instead of the one of the configuration, for
-  # example the termina kernel of ChromeOS. It boots without an initrd and
-  # must have the root filesystem and device drivers built in.
-  kernel ? null,
-  # File containing the exact expected uname -r, such as the Termina
-  # package's `release` output. Checked after the guest boots.
-  kernelRelease ? null,
-  # Seconds. The guest powers itself off when the probe ends.
   timeout ? 900,
+
 }:
 let
-  # The guest and the host of the test have the same system, so the
-  # packages of the configuration also build the test itself.
   pkgs = configuration.pkgs;
-
-  shipped = configuration.config.system.build;
-
-  bootVariant = configuration.extendModules {
-    modules = [
-      (
-        { config, lib, ... }:
-        {
-          boot.kernel.enable = lib.mkForce true;
-          boot.initrd.enable = lib.mkForce true;
-          # The scripted initrd: it hands over to the `init=` of the kernel
-          # command line, which points into the image. The systemd initrd
-          # wants a `prepare-root` there instead, which an image without
-          # an initrd does not have.
-          boot.initrd.systemd.enable = lib.mkForce false;
-          # The image loads no modules of its own: the ChromeOS kernel has
-          # them built in. The initrd loads the ones the guest needs from
-          # the NixOS kernel: virtio-gpu for the GBM device of sommelier,
-          # fuse when the guest mounts envfs.
-          boot.initrd.kernelModules = [
-            "virtio_gpu"
-          ]
-          ++ lib.optional config.services.envfs.enable "fuse";
-        }
-        # preservation asserts a systemd initrd. This variant only lends
-        # its kernel and initrd; the image keeps its own preservation. The
-        # shipped configuration tells whether the option exists at all.
-        // lib.optionalAttrs (configuration.config ? preservation) {
-          preservation.enable = lib.mkForce false;
-        }
-      )
-    ];
-  };
-
-  # nixpkgs marks sommelier broken: its test suite fails. The program
-  # builds, and the image has all its libraries at the same store paths.
+  cfg = configuration.config;
+  shipped = cfg.system.build;
+  account = shared.userAccount configuration user;
+  uid = toString account.uid;
+  kernel = pkgs.callPackage ../packages/termina-kernel.nix { };
   sommelier = pkgs.sommelier.overrideAttrs (old: {
     doCheck = false;
     buildInputs = old.buildInputs ++ [ pkgs.gtest ];
+    patches = (old.patches or [ ]) ++ [ ./sommelier-initial-configure.patch ];
     meta = old.meta // {
       broken = false;
     };
   });
-
-  # The probe runs as root in the guest. It has what the image has, and no
-  # more. The shebang is the /bin/sh of NixOS.
-  probe = pkgs.writeShellScript "probe.sh" ''
+  # Relocate the fixture's helper/data paths onto the tools disk and the
+  # guest's existing XKB link. Do not satisfy them by adding store mounts.
+  xwayland = pkgs.xwayland.overrideAttrs (old: {
+    mesonFlags =
+      lib.filter (
+        flag: !(lib.hasPrefix "-Dxkb_bin_dir=" flag || lib.hasPrefix "-Dxkb_dir=" flag)
+      ) old.mesonFlags
+      ++ [
+        "-Dxkb_bin_dir=/opt/google/cros-containers/bin"
+        "-Dxkb_dir=/usr/share/X11/xkb"
+      ];
+  });
+  units = [
+    "garcon.service"
+    "sommelier@0.service"
+    "sommelier@1.service"
+    "sommelier-x@0.service"
+    "sommelier-x@1.service"
+  ];
+  probe = pkgs.writeShellScript "baguette-probe" ''
+    set -euo pipefail
     export PATH=/run/current-system/sw/bin:/run/wrappers/bin
-    probe=/opt/google/cros-containers/probe
-    user=${user}
-    # The output goes to a serial port with a file behind it. A program
-    # that sets terminal modes can stop the port for good, so no flow
-    # control, and no program output on the port.
-    stty -ixon -ixoff -crtscts 2>/dev/null
-    as_user() {
-      runuser -u $user -- env HOME=/home/$user XDG_RUNTIME_DIR=/run/user/1000 \
-        ${lib.escapeShellArgs (lib.mapAttrsToList (k: v: "${k}=${toString v}") userEnv)} "$@"
-    }
+    export probe=/opt/google/cros-containers/probe
+    user=${lib.escapeShellArg user}
+    stty -ixon -ixoff -crtscts 2>/dev/null || true
 
-    failed=$(systemctl list-units --state=failed --no-legend --plain | awk '{print $1}' | tr '\n' ' ')
-    echo "PROBE failed [$failed]"
-    for unit in $failed; do
-      journalctl -u $unit --no-pager -o cat | tail -n 10
+    systemctl --failed --no-legend --plain > /tmp/failed-system
+    cat /tmp/failed-system
+    test ! -s /tmp/failed-system
+
+    # Check through the system manager before invoking anything as the user.
+    # setpriv below does not open a PAM session and cannot heal this failure.
+    for _ in $(seq 60); do
+      systemctl is-active --quiet user@${uid}.service && break
+      sleep 1
     done
-    echo "PROBE user $(id $user)"
+    manager=$(systemctl is-active user@${uid}.service || true)
+    echo "PROBE user-manager $manager"
+    [ "$manager" = active ] || exit 1
+    test -S /run/user/${uid}/bus
+
+    as_user() {
+      setpriv --reuid ${uid} --regid ${lib.escapeShellArg account.group} --init-groups \
+        env HOME=${lib.escapeShellArg account.home} USER="$user" LOGNAME="$user" \
+        XDG_RUNTIME_DIR=/run/user/${uid} \
+        DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/${uid}/bus "$@"
+    }
+    # Application commands inherit the environment of the real user manager.
+    # No test copy of MOZ_LEGACY_HOME, DISPLAY or the profile setup is allowed.
+    in_session() {
+      as_user systemd-run --user --quiet --wait --pipe --collect "$@"
+    }
+    for unit in ${lib.escapeShellArgs units}; do
+      for _ in $(seq 60); do
+        as_user systemctl --user is-active --quiet "$unit" && break
+        sleep 1
+      done
+      as_user systemctl --user is-active --quiet "$unit" || {
+        as_user journalctl --user -u "$unit" --no-pager -n 30
+        exit 1
+      }
+      echo "PROBE unit $unit active"
+    done
+    echo "PROBE user $(id "$user")"
     echo "PROBE kernel $(uname -r)"
-    echo "PROBE home $(stat -c '%U %a' /home/$user)"
+    echo "PROBE home $(stat -c '%U %a' ${lib.escapeShellArg account.home})"
     echo "PROBE root $(findmnt -n -b -o FSTYPE,SIZE /)"
     echo "PROBE init $(readlink /sbin/init)"
     echo "PROBE usermod $(readlink /usr/sbin/usermod)"
-
-    # The windows of the guest go through sommelier. Its units come from
-    # the image; the binary and its GBM backend come from the tools disk.
-    # On ChromeOS, maitred opens the user session and grants the render
-    # node.
-    chmod 0666 /dev/dri/renderD128 2>/dev/null
-    loginctl enable-linger $user
-    for _ in $(seq 30); do
-      as_user systemctl --user is-active --quiet sommelier@0.service 2>/dev/null && break
-      sleep 1
-    done
-    echo "PROBE sommelier $(as_user systemctl --user is-active sommelier@0.service 2>&1)" \
-      "$(test -S /run/user/1000/wayland-0 && echo wayland-0 || echo no-socket)"
-    as_user systemctl --user status sommelier@0.service --no-pager 2>&1 | tail -n 5
-
     ${extraProbe}
 
+    # Check both managers after the applications have run as well.
+    systemctl --failed --no-legend --plain > /tmp/failed-system
+    as_user systemctl --user --failed --no-legend --plain > /tmp/failed-user
+    cat /tmp/failed-system /tmp/failed-user
+    test ! -s /tmp/failed-system
+    test ! -s /tmp/failed-user
+    echo "PROBE failed []"
     echo "PROBE DONE"
   '';
-
-  # The tools of ChromeOS bring their own libraries and dynamic linker.
-  # sommelier from nixpkgs finds most of its libraries in the store of the
-  # image, at the same paths. The tools disk carries the rest, mainly the
-  # GBM backend of mesa, which the image does not ship.
+  xfonts = pkgs.runCommand "baguette-xfonts" { nativeBuildInputs = [ pkgs.mkfontscale ]; } ''
+    mkdir -p $out/misc
+    cp ${pkgs.font-misc-misc}/share/fonts/X11/misc/*.pcf.gz \
+      ${pkgs.font-cursor-misc}/share/fonts/X11/misc/*.pcf.gz \
+      ${pkgs.font-alias}/share/fonts/X11/misc/fonts.alias $out/misc/
+    mkfontdir $out/misc
+  '';
   toolsClosure = pkgs.closureInfo {
     rootPaths = [
       sommelier
       pkgs.mesa
+      xwayland
+      pkgs.xkbcomp
     ];
   };
-  imageClosure = pkgs.closureInfo { rootPaths = [ shipped.toplevel ]; };
+  toolsDisk =
+    pkgs.runCommand "cros-vm-tools-fixture.img"
+      {
+        nativeBuildInputs = [ pkgs.e2fsprogs ];
+      }
+      ''
+        mkdir -p root/bin root/lib root/probe
+        # These explicitly model no host RPC behavior. Their active state is
+        # never interpreted as successful ChromeOS registration.
+        for daemon in vshd port_listener; do
+          printf '#!/bin/sh\nexec /run/current-system/sw/bin/sleep infinity\n' > root/bin/$daemon
+        done
+        # Enforce the launch environment at garcon's actual start, without
+        # impersonating its ChromeOS registration protocol.
+        cat > root/bin/garcon <<'EOF'
+        #!/bin/sh
+        set -eu
+        test -n "$DISPLAY"
+        test -n "$DISPLAY_LOW_DENSITY"
+        test "$WAYLAND_DISPLAY" = wayland-0
+        test "$WAYLAND_DISPLAY_LOW_DENSITY" = wayland-1
+        exec /run/current-system/sw/bin/sleep infinity
+        EOF
+        printf '#!/bin/sh\nexit 0\n' > root/bin/guest_service_failure_notifier
+        cat > root/bin/maitred <<'EOF'
+        #!/bin/sh
+        export PATH=/run/current-system/sw/bin
+        systemctl is-system-running --wait >/dev/null || true
+        /opt/google/cros-containers/probe/probe.sh > /dev/ttyS1 2>&1
+        result=$?
+        echo "PROBE result $result" > /dev/ttyS1
+        systemctl poweroff --no-block
+        exec sleep infinity
+        EOF
 
-  # btrfs: the initrd loads it for the root. The image has no modules for
-  # the kernel of the test, so no other filesystem mounts in stage 2.
-  toolsDisk = pkgs.runCommand "cros-vm-tools.img" { nativeBuildInputs = [ pkgs.btrfs-progs ]; } ''
-    mkdir -p root/bin root/lib root/probe
-
-    # Stand-ins for the ChromeOS daemons. Without them, the units of the
-    # image fail and restart in a loop, and that flood stalls the serial
-    # ports of the test.
-    for daemon in vshd garcon port_listener; do
-      printf '#!/bin/sh\nexec /run/current-system/sw/bin/sleep infinity\n' > root/bin/$daemon
-    done
-    printf '#!/bin/sh\nexit 0\n' > root/bin/guest_service_failure_notifier
-
-    # The stand-in of maitred starts the probe. Its unit is part of the
-    # boot, so it waits for the end of the boot transaction first, and the
-    # probe sees which units failed. The second serial port of the test
-    # takes the output; the console of ttyS0 carries the boot messages.
-    # The guest powers off when the probe ends, whatever its result.
-    cat > root/bin/maitred <<'EOF'
-    #!/bin/sh
-    PATH=/run/current-system/sw/bin
-    systemctl is-system-running --wait > /dev/null
-    /opt/google/cros-containers/probe/probe.sh > /dev/ttyS1 2>&1
-    systemctl poweroff --force
-    EOF
-
-    # The store paths of the tools that the image lacks. The dynamic linker
-    # searches LD_LIBRARY_PATH before the RUNPATH of nixpkgs, so the copies
-    # win where the store path is absent.
-    libs=
-    for path in $(comm -13 <(sort ${imageClosure}/store-paths) <(sort ${toolsClosure}/store-paths)); do
-      [ -d $path/lib ] || continue
-      cp -r $path/lib root/lib/$(basename $path)
-      libs=$libs:/opt/google/cros-containers/lib/$(basename $path)
-    done
-    mesa=root/lib/$(basename ${pkgs.mesa})
-
-    # The sommelier units of the image call this path. The channel to the
-    # host is a virtio-gpu context, not the virtio-wl device of ChromeOS.
-    cp ${sommelier}/bin/sommelier root/bin/sommelier-bin
-    cat > root/bin/sommelier <<EOF
-    #!/bin/sh
-    export LD_LIBRARY_PATH=''${libs#:}
-    export GBM_BACKENDS_PATH=/opt/google/cros-containers/''${mesa#root/}/gbm
-    export LIBGL_DRIVERS_PATH=/opt/google/cros-containers/''${mesa#root/}/dri
-    exec /opt/google/cros-containers/bin/sommelier-bin --virtgpu-channel "\$@"
-    EOF
-
-    chmod 0755 root/bin/*
-    install -m 0755 ${probe} root/probe/probe.sh
-    ${lib.concatStringsSep "\n" (
-      lib.mapAttrsToList (target: source: "install -m 0444 ${source} root/probe/${target}") probeFiles
-    )}
-
-    truncate -s 2G $out
-    mkfs.btrfs -q -L cros-vm-tools -r root --shrink $out
-  '';
-
-  checks =
-    shared.commonChecks user
-    ++ [
-      "home ${user} ${configuration.config.users.users.${user}.homeMode}$"
-      # The Baguette module links both. The init link is the stage-2 script:
-      # `init`, or `prepare-root` with the systemd initrd.
-      "init /nix/store/.*/(init|prepare-root)$"
-      "usermod /nix/store/.*/usermod"
-      "sommelier active wayland-0"
+        # Confine fixture dependencies to the tools disk; never overlay /nix/store.
+        libs=
+        for path in $(cat ${toolsClosure}/store-paths); do
+          [ -d "$path/lib" ] || continue
+          cp -r "$path/lib" root/lib/$(basename "$path")
+          libs=$libs:/opt/google/cros-containers/lib/$(basename "$path")
+        done
+        cp ${sommelier}/bin/sommelier root/bin/sommelier-bin
+        cp ${xwayland}/bin/Xwayland root/bin/Xwayland-bin
+        cp ${pkgs.xkbcomp}/bin/xkbcomp root/bin/xkbcomp
+        cp -r ${xfonts} root/fonts
+        cat > root/bin/sommelier <<EOF
+        #!/run/current-system/sw/bin/bash
+        export LD_LIBRARY_PATH=''${libs#:}
+        export GBM_BACKENDS_PATH=/opt/google/cros-containers/lib/$(basename ${pkgs.mesa})/gbm
+        export LIBGL_DRIVERS_PATH=/opt/google/cros-containers/lib/$(basename ${pkgs.mesa})/dri
+        export SOMMELIER_XWAYLAND_GL_DRIVER_PATH=\$LIBGL_DRIVERS_PATH
+        export SOMMELIER_XFONT_PATH=/opt/google/cros-containers/fonts/misc
+        exec -a /opt/google/cros-containers/bin/sommelier /opt/google/cros-containers/bin/sommelier-bin --virtgpu-channel "\$@"
+        EOF
+        cat > root/bin/Xwayland <<EOF
+        #!/bin/sh
+        export LD_LIBRARY_PATH=''${libs#:}
+        exec /opt/google/cros-containers/bin/Xwayland-bin "\$@"
+        EOF
+        chmod 0755 root/bin/*
+        for wrapper in maitred garcon sommelier Xwayland; do
+          bash -n root/bin/$wrapper
+        done
+        install -m 0755 ${probe} root/probe/probe.sh
+        ${lib.concatStringsSep "\n" (
+          lib.mapAttrsToList (
+            target: source:
+            "install -D -m 0444 ${lib.escapeShellArg (toString source)} root/probe/${lib.escapeShellArg target}"
+          ) probeFiles
+        )}
+        truncate -s 2G "$out"
+        mkfs.ext4 -q -L cros-vm-tools -d root "$out"
+      '';
+  checks = [
+    "user-manager active$"
+    "DONE$"
+    "result 0$"
+  ]
+  ++ (
+    [
+      "failed \\[ *\\]"
+      "user uid=${uid}\\(${lib.escapeRegex user}\\)"
     ]
-    ++ extraChecks;
+    ++ [
+      "home ${user} ${account.homeMode}$"
+      "init ${shipped.toplevel}/init$"
+    ]
+    ++ map (unit: "unit ${lib.escapeRegex unit} active$") units
+    ++ extraChecks
+  );
   checkProbes = shared.mkCheckProbes pkgs checks;
 in
 pkgs.runCommand name
@@ -230,77 +224,50 @@ pkgs.runCommand name
     nativeBuildInputs = [
       pkgs.crosvm
       pkgs.coreutils
+      pkgs.weston
+      pkgs.zstd
     ];
     requiredSystemFeatures = [ "kvm" ];
+    passthru = { inherit probe checkProbes toolsDisk; };
   }
   ''
-    # A disk 2 GiB larger than the image, to also cover the resize at boot.
-    cp --sparse=always ${shipped.btrfsImage}/baguette_rootfs.img root.img
+    # Start from the same compressed artifact distributed to ChromeOS.
+    zstd -d ${shipped.btrfsImageCompressed}/baguette_rootfs.img.zst -o root.img
     cp ${toolsDisk} tools.img
     chmod u+w root.img tools.img
     image_size=$(stat -c %s root.img)
     truncate -s $((image_size + 2 * 1024 * 1024 * 1024)) root.img
-
-    # The logs go to files. Their lines end in CR and carry colors. Print
-    # them clean at the end, also on failure.
-    touch console.log probe.log
-    show_logs() {
-      for f in console.log probe.log; do
-        echo "===== $f"
-        sed 's/\r$//; s/\x1b\[[0-9;?]*[a-zA-Z]//g' $f
-        echo "===== end of $f"
-      done
+    touch console.log probe.log crosvm.log weston.log
+    cleanup() {
+      kill "$weston" 2>/dev/null || true
+      cat console.log probe.log crosvm.log weston.log
     }
-    trap show_logs EXIT
-
-    # ttyS0 is the console, ttyS1 the probe output. No getty on ttyS0: it
-    # would take the console away. The GPU gives the guest a render node,
-    # which sommelier needs.
-    timeout ${toString timeout} crosvm run --disable-sandbox --cpus 2 --mem 3072 \
+    weston=
+    trap cleanup EXIT
+    export XDG_RUNTIME_DIR=$PWD/run
+    export XDG_CACHE_HOME=$PWD/cache
+    mkdir -m 0700 "$XDG_RUNTIME_DIR"
+    mkdir "$XDG_CACHE_HOME"
+    weston --backend=headless --fake-seat --socket=wayland-host --idle-time=0 \
+      --shell=desktop --renderer=pixman --no-config --log=weston.log &
+    weston=$!
+    for _ in $(seq 60); do
+      [ -S "$XDG_RUNTIME_DIR/wayland-host" ] && break
+      sleep 0.5
+    done
+    test -S "$XDG_RUNTIME_DIR/wayland-host"
+    status=0
+    timeout ${toString timeout} crosvm run --disable-sandbox --cpus 2 --mem 4096 \
       --serial type=file,path=console.log,hardware=serial,num=1,console=true \
       --serial type=file,path=probe.log,hardware=serial,num=2 \
       --gpu backend=virglrenderer,context-types=cross-domain \
-      ${
-        if kernel != null then
-          # No initrd: the kernel mounts the root itself, as on ChromeOS.
-          ''--params "root=/dev/vdb rootfstype=btrfs rw" \''
-        else
-          "--initrd ${bootVariant.config.system.build.initialRamdisk}/initrd \\"
-      }
-      --params "init=${shipped.toplevel}/init console=ttyS0 loglevel=4 systemd.getty_auto=no" \
+      --wayland-sock "$XDG_RUNTIME_DIR/wayland-host" \
+      --params "root=/dev/vdb rw init=/sbin/init console=ttyS0" \
       --block path=tools.img --block path=root.img \
-      ${
-        if kernel != null then
-          kernel
-        else
-          "${bootVariant.config.system.build.kernel}/${bootVariant.config.system.boot.loader.kernelFile}"
-      } \
-      > crosvm.log 2>&1 || {
-      echo "crosvm exit $?"
-      tail -n 20 crosvm.log
-    }
-
-    mkdir -p $out
-    cp console.log probe.log crosvm.log $out/
-
-    # systemd sends a terminal query to the tty before the first line.
-    sed 's/\r$//' probe.log | grep -o 'PROBE .*' > probes || true
-    cat probes
-
-    status=0
-    ${lib.optionalString (kernelRelease != null) ''
-      expected_release=$(cat ${lib.escapeShellArg kernelRelease})
-      if ! grep -Fxq "PROBE kernel $expected_release" probes; then
-        echo "FAIL: booted kernel does not match expected release: $expected_release"
-        status=1
-      fi
-    ''}
-    # Activation grows the filesystem to the size of the disk.
-    root_size=$(grep -o '^PROBE root btrfs *[0-9]*' probes | grep -o '[0-9]*$')
-    if [ -z "$root_size" ] || [ "$root_size" -le "$image_size" ]; then
-      echo "FAIL: root filesystem not grown: $root_size <= $image_size"
-      status=1
-    fi
-    ${checkProbes} probe.log || status=1
-    exit $status
+      ${kernel}/kernel > crosvm.log 2>&1 || status=$?
+    mkdir "$out"
+    cp *.log "$out/"
+    sha256sum ${shipped.btrfsImageCompressed}/baguette_rootfs.img.zst ${kernel}/kernel ${toolsDisk} > "$out/inputs.sha256"
+    bash ${./verify-boot.sh} "$status" probe.log ${checkProbes} \
+      ${kernel}/release "$image_size"
   ''

--- a/tests/guest-session.nix
+++ b/tests/guest-session.nix
@@ -1,0 +1,197 @@
+# Evaluate the module contract without a VM or the template's user settings.
+{ nixpkgs, system }:
+let
+  inherit (nixpkgs) lib;
+  pkgs = nixpkgs.legacyPackages.${system};
+  make =
+    module: modules:
+    (lib.nixosSystem {
+      inherit system;
+      modules = [
+        module
+        { system.stateVersion = "25.05"; }
+      ]
+      ++ modules;
+    }).config;
+  settings.users.users = {
+    alice = {
+      isNormalUser = true;
+      crostini.enable = true;
+    };
+    # Selection must not depend on account iteration order.
+    bob = {
+      isNormalUser = true;
+      uid = 1001;
+    };
+  };
+  valid = make ../baguette.nix [ settings ];
+  customUid = make ../baguette.nix [
+    settings
+    { users.users.alice.uid = 1234; }
+  ];
+  renamed = make ../baguette.nix [
+    {
+      users.users.login = {
+        name = "alice";
+        isNormalUser = true;
+        crostini.enable = true;
+      };
+    }
+  ];
+  multiple = make ../baguette.nix [
+    settings
+    { users.users.bob.crostini.enable = true; }
+  ];
+  multipleDefaultUid = make ../baguette.nix [
+    {
+      users.users = lib.genAttrs [ "alice" "bob" ] (_: {
+        isNormalUser = true;
+        crostini.enable = true;
+      });
+    }
+  ];
+  multipleMessage = "Crostini: only one user may enable crostini.enable; enabled for: users.users.alice, users.users.bob.";
+  switched = make ../baguette.nix [
+    settings
+    {
+      users.users.alice.crostini.enable = lib.mkForce false;
+      users.users.bob.crostini.enable = true;
+    }
+  ];
+  legacySettings.users.users = {
+    alice = {
+      isNormalUser = true;
+      uid = 1234;
+      linger = true;
+      extraGroups = [ "wheel" ];
+    };
+    bob = {
+      isNormalUser = true;
+      uid = 1235;
+      linger = false;
+    };
+  };
+  legacy = make ../baguette.nix [ legacySettings ];
+  legacyLxc = make ../crostini.nix [ legacySettings ];
+  unset = make ../baguette.nix [ { users.users.alice.isNormalUser = true; } ];
+  failures = c: map (a: a.message) (lib.filter (a: !a.assertion) c.assertions);
+  sessionFailures = c: lib.filter (lib.hasPrefix "Crostini:") (failures c);
+  sessionWarnings = c: lib.filter (lib.hasPrefix "No user has crostini.enable set;") c.warnings;
+  rejected = modules: sessionFailures (make ../baguette.nix modules) != [ ];
+  units = [
+    "sommelier@0.service"
+    "sommelier@1.service"
+    "sommelier-x@0.service"
+    "sommelier-x@1.service"
+  ];
+  mount = "opt-google-cros\\x2dcontainers.mount";
+  shared = import ./lib.nix { inherit lib; };
+in
+assert failures valid == [ ];
+assert sessionWarnings valid == [ ];
+assert valid.users.users.alice.linger;
+assert valid.users.users.alice.uid == 1000;
+assert valid.users.users.bob.linger != true;
+assert lib.all (group: lib.elem group valid.users.users.alice.extraGroups) [
+  "render"
+  "video"
+];
+assert valid.systemd.services."user@1000".overrideStrategy == "asDropin";
+assert lib.elem mount valid.systemd.services."user@1000".requires;
+assert lib.elem mount valid.systemd.services."user@1000".after;
+assert lib.elem mount customUid.systemd.services."user@1234".after;
+assert valid.systemd.user.services.garcon.unitConfig.ConditionUser == "alice";
+assert lib.all (
+  unit:
+  lib.elem unit valid.systemd.user.services.garcon.requires
+  && lib.elem unit valid.systemd.user.services.garcon.after
+) units;
+assert failures renamed == [ ];
+assert renamed.users.users.login.uid == 1000 && renamed.users.users.login.linger;
+assert renamed.systemd.user.services.garcon.unitConfig.ConditionUser == "alice";
+assert !(renamed.users.users ? alice);
+assert shared.defaultUser "test" { config = renamed; } == "alice";
+assert (shared.userAccount { config = renamed; } "alice").uid == 1000;
+# Two enabled accounts must fail the real system evaluation, naming both.
+assert
+  sessionFailures multiple == [
+    "Crostini: only one user may enable crostini.enable; enabled for: users.users.alice, users.users.bob."
+  ];
+assert !(builtins.tryEval multiple.system.build.toplevel.drvPath).success;
+assert !(multiple.systemd.user.services.garcon.unitConfig ? ConditionUser);
+assert sessionWarnings multiple == [ ];
+# Normal module overrides can move the selection to another account.
+assert failures switched == [ ];
+assert switched.systemd.user.services.garcon.unitConfig.ConditionUser == "bob";
+assert switched.users.users.alice.linger != true;
+assert switched.users.users.bob.linger;
+assert !(switched.systemd.services ? "user@1000");
+assert lib.elem mount switched.systemd.services."user@1001".after;
+# Repeating the flag on the same account is not a second selection.
+assert
+  failures (
+    make ../baguette.nix [
+      settings
+      { users.users.alice.crostini.enable = true; }
+    ]
+  ) == [ ];
+# Unset is compatible, but never guesses a user or repairs the session.
+assert sessionFailures unset == [ ];
+assert lib.length (sessionWarnings unset) == 1;
+assert unset.users.users.alice.linger != true;
+assert lib.all
+  (
+    c:
+    failures c == [ ]
+    && builtins.isString c.system.build.toplevel.drvPath
+    && lib.length (sessionWarnings c) == 1
+    && c.users.users.alice.uid == 1234
+    && c.users.users.alice.linger
+    && c.users.users.bob.linger == false
+    && lib.elem "wheel" c.users.users.alice.extraGroups
+    && !(lib.elem "render" c.users.users.alice.extraGroups)
+    && !(lib.elem "video" c.users.users.alice.extraGroups)
+    && !(c.systemd.user.services.garcon.unitConfig ? ConditionUser)
+    && !(c.systemd.services ? "user@1234")
+  )
+  [
+    legacy
+    legacyLxc
+  ];
+assert rejected [
+  settings
+  { users.users.alice.enable = false; }
+];
+assert rejected [
+  settings
+  { users.users.alice.uid = 0; }
+];
+assert rejected [ { users.users.root.crostini.enable = true; } ];
+assert rejected [
+  {
+    users.users.daemon = {
+      crostini.enable = true;
+      isSystemUser = true;
+      group = "daemon";
+    };
+    users.groups.daemon = { };
+  }
+];
+assert rejected [ { users.users.incomplete.crostini.enable = true; } ];
+assert lib.all
+  (
+    linger:
+    rejected [
+      settings
+      { users.users.alice.linger = linger; }
+    ]
+  )
+  [
+    false
+    null
+    (lib.mkForce false)
+  ];
+# Legacy LXC users may still be provisioned by the host, without this option.
+assert sessionFailures (make ../crostini.nix [ ]) == [ ];
+assert (make ../crostini.nix [ settings ]).users.users.alice.linger;
+pkgs.runCommand "crostini-guest-session-configuration" { } "touch $out"

--- a/tests/guest-session.nix
+++ b/tests/guest-session.nix
@@ -76,7 +76,8 @@ let
   unset = make ../baguette.nix [ { users.users.alice.isNormalUser = true; } ];
   failures = c: map (a: a.message) (lib.filter (a: !a.assertion) c.assertions);
   sessionFailures = c: lib.filter (lib.hasPrefix "Crostini:") (failures c);
-  sessionWarnings = c: lib.filter (lib.hasPrefix "No user has crostini.enable set;") c.warnings;
+  # Identify the migration advice by its option, not the surrounding prose.
+  sessionWarnings = c: lib.filter (lib.hasInfix "users.users.<name>.crostini.enable") c.warnings;
   rejected = modules: sessionFailures (make ../baguette.nix modules) != [ ];
   units = [
     "sommelier@0.service"
@@ -113,10 +114,9 @@ assert !(renamed.users.users ? alice);
 assert shared.defaultUser "test" { config = renamed; } == "alice";
 assert (shared.userAccount { config = renamed; } "alice").uid == 1000;
 # Two enabled accounts must fail the real system evaluation, naming both.
-assert
-  sessionFailures multiple == [
-    "Crostini: only one user may enable crostini.enable; enabled for: users.users.alice, users.users.bob."
-  ];
+assert failures multiple == [ multipleMessage ];
+assert lib.elem multipleMessage (failures multipleDefaultUid);
+assert !(builtins.tryEval multipleDefaultUid.system.build.toplevel.drvPath).success;
 assert !(builtins.tryEval multiple.system.build.toplevel.drvPath).success;
 assert !(multiple.systemd.user.services.garcon.unitConfig ? ConditionUser);
 assert sessionWarnings multiple == [ ];

--- a/tests/lib.nix
+++ b/tests/lib.nix
@@ -11,12 +11,21 @@
   defaultUser =
     who: configuration:
     let
-      users = lib.attrNames (lib.filterAttrs (_: u: u.isNormalUser) configuration.config.users.users);
+      accounts = lib.attrValues configuration.config.users.users;
+      selected = lib.filter (u: u.crostini.enable) accounts;
+      normal = lib.filter (u: u.isNormalUser) accounts;
+      candidates = if selected != [ ] then selected else normal;
     in
-    if lib.length users == 1 then
-      lib.head users
+    if lib.length candidates == 1 then
+      (lib.head candidates).name
     else
-      throw "${who}: specify user when the image does not have exactly one normal user";
+      throw "${who}: enable crostini.enable for one user, or specify user for a legacy image";
+
+  userAccount =
+    configuration: user:
+    lib.findSingle (account: account.name == user) (throw "No configured user named ${user}")
+      (throw "Multiple configured users named ${user}")
+      (lib.attrValues configuration.config.users.users);
 
   # The start of a probe. `setup` runs before the first check. The
   # shebang is the /bin/sh of NixOS.

--- a/tests/verify-boot.nix
+++ b/tests/verify-boot.nix
@@ -1,0 +1,44 @@
+{ pkgs }:
+let
+  shared = import ./lib.nix { inherit (pkgs) lib; };
+  check = shared.mkCheckProbes pkgs [
+    "user-manager active$"
+    "DONE$"
+    "result 0$"
+  ];
+in
+pkgs.runCommand "baguette-boot-verifier" { } ''
+  cat > good.log <<'EOF'
+  PROBE user-manager active
+  PROBE kernel fixture-kernel
+  PROBE root btrfs 200
+  PROBE DONE
+  PROBE result 0
+  EOF
+  echo fixture-kernel > release
+  verify() {
+    bash ${./verify-boot.sh} "$1" "$2" ${check} release 100
+  }
+  reject() {
+    if verify "$1" "$2"; then
+      echo "FAIL: accepted $1 $2" >&2
+      exit 1
+    fi
+  }
+  verify 0 good.log
+  sed 's/$/\r/' good.log > crlf.log
+  verify 0 crlf.log
+  reject 124 good.log # Timeout after all probes were printed.
+  reject 1 good.log   # Failed shutdown after all probes were printed.
+  sed '/PROBE DONE/d' good.log > truncated.log
+  reject 0 truncated.log
+  sed 's/result 0/result 1/' good.log > failed.log
+  reject 0 failed.log
+  sed 's/user-manager active/user-manager inactive/' good.log > no-session.log
+  reject 0 no-session.log
+  sed 's/fixture-kernel/wrong-kernel/' good.log > wrong-kernel.log
+  reject 0 wrong-kernel.log
+  sed 's/btrfs 200/btrfs 100/' good.log > no-resize.log
+  reject 0 no-resize.log
+  touch "$out"
+''

--- a/tests/verify-boot.sh
+++ b/tests/verify-boot.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# A complete probe log cannot excuse a VM timeout or failed shutdown.
+set -euo pipefail
+vm_status=${1:?VM exit status required}
+probe_log=${2:?Probe log required}
+check_probes=${3:?Probe checker required}
+kernel_release=${4:?Kernel release file required}
+image_size=${5:?Original image size required}
+
+if [ "$vm_status" -ne 0 ]; then
+  echo "FAIL: crosvm exited with status $vm_status" >&2
+  exit 1
+fi
+"$check_probes" "$probe_log"
+
+tr -d '\r' < "$probe_log" | grep -Fx "PROBE kernel $(cat "$kernel_release")" > /dev/null
+root_size=$(tr -d '\r' < "$probe_log" | sed -n 's/^PROBE root btrfs *\([0-9]*\).*$/\1/p')
+if [[ ! "$root_size" =~ ^[0-9]+$ ]] || [ "$root_size" -le "$image_size" ]; then
+  echo "FAIL: root filesystem was not grown" >&2
+  exit 1
+fi


### PR DESCRIPTION
Before we had an implicit requirement on `linger = true` since crostini needs `garcon` and `sommelier` to start with the VM regardless of user login. With `crostini.enable = true` we make that requirement explicit and more robust.